### PR TITLE
Fix SSR warning emitted by gatsby develop

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,14 @@ const JsEnabledContext = React.createContext(false);
 function JsEnabledProvider({ children }) {
   const [isJsEnabled, setIsJsEnabled] = React.useState(false);
 
-  React.useLayoutEffect(() => {
-    setIsJsEnabled(true);
-  }, []);
+  if (typeof window !== 'undefined')
+    React.useLayoutEffect(() => {
+      setIsJsEnabled(true);
+    }, []);
+  else
+    React.useEffect(() => {
+      setIsJsEnabled(true);
+    }, []);
 
   return React.createElement(JsEnabledContext.Provider, { value: isJsEnabled }, children);
 }

--- a/index.js
+++ b/index.js
@@ -5,14 +5,9 @@ const JsEnabledContext = React.createContext(false);
 function JsEnabledProvider({ children }) {
   const [isJsEnabled, setIsJsEnabled] = React.useState(false);
 
-  if (typeof window !== 'undefined')
-    React.useLayoutEffect(() => {
-      setIsJsEnabled(true);
-    }, []);
-  else
-    React.useEffect(() => {
-      setIsJsEnabled(true);
-    }, []);
+  React.useEffect(() => {
+    setIsJsEnabled(true);
+  }, []);
 
   return React.createElement(JsEnabledContext.Provider, { value: isJsEnabled }, children);
 }


### PR DESCRIPTION
This error message appears in the `gatsby develop` console wherever `useIsJsEnabled` is used.
```
Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.
```